### PR TITLE
Get the bounding rectangle after drag move.

### DIFF
--- a/src/jsx/panel.js
+++ b/src/jsx/panel.js
@@ -47,6 +47,10 @@ var FloatingPanel = React.createClass({
   dragEnd: function() {
     delete this.panelBounds;
     window.removeEventListener('dragover', this.dragOver);
+    if (this.props.onBoundsChange) {
+      var height=this.getDOMNode().offsetHeight;
+      this.props.onBoundsChange({left:this.state.left, top:this.state.top, width:this.state.width, height:height});
+    }
   },
 
   dragOver: function(e) {


### PR DESCRIPTION
bounding rectangle is needed for saving the of the position of a floating panel.
